### PR TITLE
Fixed bug where dynamic phrases weren't processed correctly

### DIFF
--- a/Util.cs
+++ b/Util.cs
@@ -2,11 +2,19 @@
 using System.Security.Cryptography;
 using System.IO;
 using System.Text;
+using System.Collections.Generic;
 
 namespace MSCognitiveTextToSpeech
 {
-    public class Utils
+    public static class Utils
     {
+       
+        public static T PickRandom<T>(this List<T> enumerable)
+        {
+            int index = new Random().Next(0, enumerable.Count);
+            return enumerable[index];
+        }
+       
 
         public static string GetHashedName(MemoryStream ms)
         {

--- a/VAPluginClass.cs
+++ b/VAPluginClass.cs
@@ -10,6 +10,7 @@ using System;
 using System.Xml;
 using System.Xml.Linq;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using Microsoft.CognitiveServices.Speech;
@@ -104,6 +105,11 @@ namespace MSCognitiveTextToSpeech
             else
                 context = vaProxy.Context;
 
+            // since the context could contain dynamic tokens/phrases, we need to extract one
+            string[] possiblePhrases = vaProxy.Utility.ExtractPhrases(context);
+            string selectedPhrase = possiblePhrases.ToList().PickRandom();
+   
+
             // see if we have a valid configuration file
             Configuration config = new Configuration();
             if (!config.Exists() && config.SettingCount == 0)
@@ -114,7 +120,7 @@ namespace MSCognitiveTextToSpeech
 
             // proceed with the text-to-speech process
             if (DebugMode(vaProxy)) vaProxy.WriteToLog(LOG_PREFIX + "Processing context: " + context, LOG_INFO);
-            await InvokeTextToSpeech(vaProxy, context);
+            await InvokeTextToSpeech(vaProxy, selectedPhrase);
             
             // if we get this far we've processed the command
             vaProxy.WriteToLog(LOG_PREFIX + "Context processed: " + context, LOG_NORMAL);


### PR DESCRIPTION
If a phrase had dynamic tokens (i.e. [hello;hi] bob) it was speaking all the words (hello, hi, bob).   With the fix, it will get a single dynamic phrase at random from the context (i.e. Hi Bob)